### PR TITLE
Link is outdated.

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,4 +6,4 @@ The new function analogReadFast() takes just 21us.
 - AVR boards: Arduino Uno, Nano, Mega, Leonardo, etc.
 - SAMD21 boards: Arduino Zero, SAM 15x15, etc. 
 
-http://www.avdweb.nl/arduino/libraries/fast-10-bit-adc.html
+https://www.avdweb.nl/arduino/adc-dac/fast-10-bit-adc


### PR DESCRIPTION
As the classic Arduino IDE reads this README.md file (I assume) the outdated link is shown in the classic Arduino IDE. Would be nice to correct it.