### PR TITLE
Fix slow ADMUX switch on AVR

### DIFF
--- a/avdweb_AnalogReadFast.h
+++ b/avdweb_AnalogReadFast.h
@@ -11,7 +11,7 @@ HISTORY:
 
 int inline analogReadFast(byte ADCpin);
 
-#if defined(__arm__) 
+#if defined(__arm__)
 int inline analogReadFast(byte ADCpin)    // inline library functions must be in header
 { ADC->CTRLA.bit.ENABLE = 0;              // disable ADC
   while( ADC->STATUS.bit.SYNCBUSY == 1 ); // wait for synchronization
@@ -19,29 +19,30 @@ int inline analogReadFast(byte ADCpin)    // inline library functions must be in
   int CTRLBoriginal = ADC->CTRLB.reg;
   int AVGCTRLoriginal = ADC->AVGCTRL.reg;
   int SAMPCTRLoriginal = ADC->SAMPCTRL.reg;
-  
+
   ADC->CTRLB.reg &= 0b1111100011111111;          // mask PRESCALER bits
   ADC->CTRLB.reg |= ADC_CTRLB_PRESCALER_DIV64;   // divide Clock by 64
-  ADC->AVGCTRL.reg = ADC_AVGCTRL_SAMPLENUM_1 |   // take 1 sample 
+  ADC->AVGCTRL.reg = ADC_AVGCTRL_SAMPLENUM_1 |   // take 1 sample
                      ADC_AVGCTRL_ADJRES(0x00ul); // adjusting result by 0
   ADC->SAMPCTRL.reg = 0x00;                      // sampling Time Length = 0
 
   ADC->CTRLA.bit.ENABLE = 1;                     // enable ADC
   while(ADC->STATUS.bit.SYNCBUSY == 1);          // wait for synchronization
 
-  int adc = analogRead(ADCpin); 
-  
+  int adc = analogRead(ADCpin);
+
   ADC->CTRLB.reg = CTRLBoriginal;
   ADC->AVGCTRL.reg = AVGCTRLoriginal;
   ADC->SAMPCTRL.reg = SAMPCTRLoriginal;
-   
+
   return adc;
 }
 #else
-int inline analogReadFast(byte ADCpin) 
-{ byte ADCSRAoriginal = ADCSRA; 
-  ADCSRA = (ADCSRA & B11111000) | 4; 
-  int adc = analogRead(ADCpin);  
+int inline analogReadFast(byte ADCpin)
+{ byte ADCSRAoriginal = ADCSRA;
+  ADCSRA = (ADCSRA & B11111000) | 4;
+  int adc = analogRead(ADCpin);         // Initialize variable and burn a read
+  adc = analogRead(ADCpin);             // because ADMUX takes 2.5us to switch
   ADCSRA = ADCSRAoriginal;
   return adc;
 }


### PR DESCRIPTION
On the AVR, ADC speeds over 500KHz can result in unreliable ADC results if reading multiple different pins in a row because ADMUX takes ~2.5us to finish switching pins. By burning a single ADC read before returning a result we can satisfy this switching time requirement without using delays.

Resolves #5 